### PR TITLE
Support for ARMCC6

### DIFF
--- a/source/nordic_sdk/components/drivers_nrf/delay/nrf_delay.h
+++ b/source/nordic_sdk/components/drivers_nrf/delay/nrf_delay.h
@@ -111,7 +111,7 @@ loop
         BX     LR
 }
 
-#elif defined ( __ICCARM__ ) || (__ARMCC_VERSION)
+#elif defined ( __ICCARM__ ) || (__ARMCC_VERSION >= 6000000)
 
 static void __INLINE nrf_delay_us(uint32_t volatile number_of_us)
 {

--- a/source/nordic_sdk/components/drivers_nrf/delay/nrf_delay.h
+++ b/source/nordic_sdk/components/drivers_nrf/delay/nrf_delay.h
@@ -111,7 +111,7 @@ loop
         BX     LR
 }
 
-#elif defined ( __ICCARM__ )
+#elif defined ( __ICCARM__ ) || (__ARMCC_VERSION)
 
 static void __INLINE nrf_delay_us(uint32_t volatile number_of_us)
 {

--- a/source/nordic_sdk/components/libraries/experimental_section_vars/section_vars.h
+++ b/source/nordic_sdk/components/libraries/experimental_section_vars/section_vars.h
@@ -59,7 +59,7 @@
  *
  * @param[in]   section_name    Name of the section to register
  **/
-#if defined __CC_ARM
+#if defined (_CC_ARM) || (__ARMCC_VERSION)
 
 // Not required by this compiler
 #define NRF_SECTION_VARS_REGISTER_SECTION(section_name)
@@ -88,7 +88,7 @@
  *
  * @param[in]   section_name    Name of the section
  */
-#if defined __CC_ARM
+#if defined (_CC_ARM) || (__ARMCC_VERSION)
 
 #define NRF_SECTION_VARS_START_SYMBOL(section_name)         section_name ## $$Base
 
@@ -114,7 +114,7 @@
  *
  * @param[in]   section_name    Name of the section    
  */
-#if defined __CC_ARM
+#if defined (_CC_ARM) || (__ARMCC_VERSION)
 
 #define NRF_SECTION_VARS_END_SYMBOL(section_name)           section_name ## $$Limit
 
@@ -138,7 +138,7 @@
  * @param[in]   section_name    Name of the section
  */
 
-#if defined __CC_ARM
+#if defined (_CC_ARM) || (__ARMCC_VERSION)
 
 #define NRF_SECTION_VARS_LENGTH(section_name) \
     ((uint32_t)&NRF_SECTION_VARS_END_SYMBOL(section_name) - (uint32_t)&NRF_SECTION_VARS_START_SYMBOL(section_name))
@@ -164,7 +164,7 @@
  *
  * param[in]    section_name    Name of the section to get the start address from
  */
-#if defined __CC_ARM
+#if defined (_CC_ARM) || (__ARMCC_VERSION)
 
 #define NRF_SECTION_VARS_START_ADDR(section_name)       (uint32_t)&NRF_SECTION_VARS_START_SYMBOL(section_name)
       
@@ -187,7 +187,7 @@
  *
  * @param[in]   section_name    Name of the section to get end address from
  */
-#if defined __CC_ARM
+#if defined (_CC_ARM) || (__ARMCC_VERSION)
 
 #define NRF_SECTION_VARS_END_ADDR(section_name)         (uint32_t)&NRF_SECTION_VARS_END_SYMBOL(section_name)
       
@@ -213,7 +213,7 @@
  * @param[in]   type_name       Name of the type stored in the section
  * @param[in]   section_name    Name of the section
  */
-#if defined __CC_ARM
+#if defined (_CC_ARM) || (__ARMCC_VERSION)
 
 #define NRF_SECTION_VARS_REGISTER_SYMBOLS(type_name, section_name)      \
     extern type_name* NRF_SECTION_VARS_START_SYMBOL(section_name);      \
@@ -253,7 +253,7 @@
  * @param[in]   section_name    Name of the section
  * @param[in]   type_def        Datatype of the symbol to place in the given section
  */
-#if defined __CC_ARM
+#if defined (_CC_ARM) || (__ARMCC_VERSION)
     
 #define NRF_SECTION_VARS_ADD(section_name, type_def) \
     static type_def __attribute__((section( #section_name ))) __attribute__((used))
@@ -288,7 +288,7 @@
  * @param[in]   section_name    Name of the section
  */
       
-#if defined __CC_ARM
+#if defined (_CC_ARM) || (__ARMCC_VERSION)
 
 #define NRF_SECTION_VARS_GET(i, type_name, section_name) \
     (type_name*)(NRF_SECTION_VARS_START_ADDR(section_name) + i * sizeof(type_name))

--- a/source/nordic_sdk/components/libraries/experimental_section_vars/section_vars.h
+++ b/source/nordic_sdk/components/libraries/experimental_section_vars/section_vars.h
@@ -59,7 +59,7 @@
  *
  * @param[in]   section_name    Name of the section to register
  **/
-#if defined (_CC_ARM) || (__ARMCC_VERSION)
+#if defined (__CC_ARM)
 
 // Not required by this compiler
 #define NRF_SECTION_VARS_REGISTER_SECTION(section_name)
@@ -69,7 +69,7 @@
 // Not required by this compiler
 #define NRF_SECTION_VARS_REGISTER_SECTION(section_name)
 
-#elif defined __ICCARM__
+#elif defined (__ICCARM__) || (__ARMCC_VERSION)
 
 #define NRF_SECTION_VARS_REGISTER_SECTION(section_name) NRF_PRAGMA(section = ## #section_name )
 

--- a/source/nordic_sdk/components/libraries/experimental_section_vars/section_vars.h
+++ b/source/nordic_sdk/components/libraries/experimental_section_vars/section_vars.h
@@ -35,7 +35,7 @@
 
 #include "app_util.h"
 
-#if defined __ICC_ARM__
+#if defined (__ICC_ARM__) || (__ARMCC_VERSION >= 6000000)
 
 // turn on language extensions for iar
 #pragma language=extended
@@ -59,7 +59,7 @@
  *
  * @param[in]   section_name    Name of the section to register
  **/
-#if defined (__CC_ARM)
+#if defined __CC_ARM
 
 // Not required by this compiler
 #define NRF_SECTION_VARS_REGISTER_SECTION(section_name)
@@ -69,7 +69,7 @@
 // Not required by this compiler
 #define NRF_SECTION_VARS_REGISTER_SECTION(section_name)
 
-#elif defined (__ICCARM__) || (__ARMCC_VERSION)
+#elif defined (__ICCARM__) || (__ARMCC_VERSION >= 6000000)
 
 #define NRF_SECTION_VARS_REGISTER_SECTION(section_name) NRF_PRAGMA(section = ## #section_name )
 
@@ -88,7 +88,7 @@
  *
  * @param[in]   section_name    Name of the section
  */
-#if defined (_CC_ARM) || (__ARMCC_VERSION)
+#if defined __CC_ARM
 
 #define NRF_SECTION_VARS_START_SYMBOL(section_name)         section_name ## $$Base
 
@@ -96,7 +96,7 @@
 
 #define NRF_SECTION_VARS_START_SYMBOL(section_name)         __start_ ## section_name
 
-#elif defined __ICCARM__
+#elif defined (__ICCARM__) || (__ARMCC_VERSION >= 6000000)
 
 #define NRF_SECTION_VARS_START_SYMBOL(section_name)         __section_begin(#section_name)
 
@@ -114,7 +114,7 @@
  *
  * @param[in]   section_name    Name of the section    
  */
-#if defined (_CC_ARM) || (__ARMCC_VERSION)
+#if defined __CC_ARM
 
 #define NRF_SECTION_VARS_END_SYMBOL(section_name)           section_name ## $$Limit
 
@@ -122,7 +122,7 @@
 
 #define NRF_SECTION_VARS_END_SYMBOL(section_name)           __stop_ ## section_name
 
-#elif defined __ICCARM__
+#elif defined (__ICCARM__) || (__ARMCC_VERSION >= 6000000)
 
 #define NRF_SECTION_VARS_END_SYMBOL(section_name)           __section_end(#section_name)
 
@@ -138,7 +138,7 @@
  * @param[in]   section_name    Name of the section
  */
 
-#if defined (_CC_ARM) || (__ARMCC_VERSION)
+#if defined __CC_ARM
 
 #define NRF_SECTION_VARS_LENGTH(section_name) \
     ((uint32_t)&NRF_SECTION_VARS_END_SYMBOL(section_name) - (uint32_t)&NRF_SECTION_VARS_START_SYMBOL(section_name))
@@ -148,7 +148,7 @@
  #define NRF_SECTION_VARS_LENGTH(section_name) \
     ((uint32_t)&NRF_SECTION_VARS_END_SYMBOL(section_name) - (uint32_t)&NRF_SECTION_VARS_START_SYMBOL(section_name))
 
-#elif defined __ICCARM__
+#elif defined (__ICCARM__) || (__ARMCC_VERSION >= 6000000)
 
  #define NRF_SECTION_VARS_LENGTH(section_name) \
     ((uint32_t)NRF_SECTION_VARS_END_SYMBOL(section_name) - (uint32_t)NRF_SECTION_VARS_START_SYMBOL(section_name))
@@ -164,7 +164,7 @@
  *
  * param[in]    section_name    Name of the section to get the start address from
  */
-#if defined (_CC_ARM) || (__ARMCC_VERSION)
+#if defined __CC_ARM
 
 #define NRF_SECTION_VARS_START_ADDR(section_name)       (uint32_t)&NRF_SECTION_VARS_START_SYMBOL(section_name)
       
@@ -172,7 +172,7 @@
       
 #define NRF_SECTION_VARS_START_ADDR(section_name)       (uint32_t)&NRF_SECTION_VARS_START_SYMBOL(section_name)
       
-#elif defined __ICCARM__
+#elif defined (__ICCARM__) || (__ARMCC_VERSION >= 6000000)
       
 #define NRF_SECTION_VARS_START_ADDR(section_name)       (uint32_t)iar_ ## section_name ## _start
 
@@ -187,7 +187,7 @@
  *
  * @param[in]   section_name    Name of the section to get end address from
  */
-#if defined (_CC_ARM) || (__ARMCC_VERSION)
+#if defined __CC_ARM
 
 #define NRF_SECTION_VARS_END_ADDR(section_name)         (uint32_t)&NRF_SECTION_VARS_END_SYMBOL(section_name)
       
@@ -195,7 +195,7 @@
 
 #define NRF_SECTION_VARS_END_ADDR(section_name)         (uint32_t)&NRF_SECTION_VARS_END_SYMBOL(section_name)
       
-#elif defined __ICCARM__
+#elif defined (__ICCARM__) || (__ARMCC_VERSION >= 6000000)
 
 #define NRF_SECTION_VARS_END_ADDR(section_name)         (uint32_t)iar_ ## section_name ## _end
 
@@ -213,7 +213,7 @@
  * @param[in]   type_name       Name of the type stored in the section
  * @param[in]   section_name    Name of the section
  */
-#if defined (_CC_ARM) || (__ARMCC_VERSION)
+#if defined __CC_ARM
 
 #define NRF_SECTION_VARS_REGISTER_SYMBOLS(type_name, section_name)      \
     extern type_name* NRF_SECTION_VARS_START_SYMBOL(section_name);      \
@@ -225,7 +225,7 @@
     extern type_name* NRF_SECTION_VARS_START_SYMBOL(section_name);      \
     extern void* NRF_SECTION_VARS_END_SYMBOL(section_name)
 
-#elif defined __ICCARM__
+#elif defined (__ICCARM__) || (__ARMCC_VERSION >= 6000000)
 
 // No symbol registration required for IAR      
 #define NRF_SECTION_VARS_REGISTER_SYMBOLS(type_name, section_name)                              \
@@ -253,7 +253,7 @@
  * @param[in]   section_name    Name of the section
  * @param[in]   type_def        Datatype of the symbol to place in the given section
  */
-#if defined (_CC_ARM) || (__ARMCC_VERSION)
+#if defined __CC_ARM
     
 #define NRF_SECTION_VARS_ADD(section_name, type_def) \
     static type_def __attribute__((section( #section_name ))) __attribute__((used))
@@ -263,7 +263,7 @@
 #define NRF_SECTION_VARS_ADD(section_name, type_def) \
     static type_def __attribute__ ((section( #section_name ))) __attribute__ ((used))
 
-#elif defined __ICCARM__
+#elif defined (__ICCARM__) || (__ARMCC_VERSION >= 6000000)
 
 #define NRF_SECTION_VARS_ADD(section_name, type_def) \
     __root type_def @ #section_name
@@ -288,7 +288,7 @@
  * @param[in]   section_name    Name of the section
  */
       
-#if defined (_CC_ARM) || (__ARMCC_VERSION)
+#if defined __CC_ARM
 
 #define NRF_SECTION_VARS_GET(i, type_name, section_name) \
     (type_name*)(NRF_SECTION_VARS_START_ADDR(section_name) + i * sizeof(type_name))
@@ -298,7 +298,7 @@
 #define NRF_SECTION_VARS_GET(i, type_name, section_name) \
     (type_name*)(NRF_SECTION_VARS_START_ADDR(section_name) + i * sizeof(type_name))
       
-#elif defined __ICCARM__
+#elif defined (__ICCARM__) || (__ARMCC_VERSION >= 6000000)
 
 #define NRF_SECTION_VARS_GET(i, type_name, section_name) \
       (type_name*)iar_ ## section_name ## _start + (i * sizeof(type_name))


### PR DESCRIPTION
Check for __CC_ARM or __ARMCC_VERSION

These changes are necessary to build the DAL in ARMCC6, which the mbed online compiler uses

Linked to:
nrf51-sdk: https://github.com/lancaster-university/nrf51-sdk/pull/1
mbed-classic: https://github.com/lancaster-university/mbed-classic/pull/13
microbit-dal: 